### PR TITLE
Tooltip features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stormwind"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "clap",
  "compact_str",

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,23 @@ enum UnitsPrecipitation {
     Inch,
 }
 
+#[derive(clap::ValueEnum, Clone, Default, Debug, Deserialize, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+enum AqiStandard {
+    #[default]
+    European,
+    Us,
+}
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, Deserialize, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+enum AqiDomain {
+    #[default]
+    Auto,
+    CamsEurope,
+    CamsGlobal,
+}
+
 #[derive(Parser, Deserialize, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -49,6 +66,12 @@ struct Args {
 
     #[arg(long, value_enum, default_value_t)]
     units_precipitation: UnitsPrecipitation,
+
+    #[arg(long, value_enum, default_value_t, help = "Air Quality Index standard to use (European or US)")]
+    aqi_standard: AqiStandard,
+    
+    #[arg(long, value_enum, default_value_t, help = "AQI domain to use (auto, cams_europe, or cams_global)")]
+    aqi_domain: AqiDomain,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
         80..=82 => "🌧️",       // Rain showers
         85 | 86 => "🌨️",       // Snow showers
         95..=97 => "⛈️",       // Thunderstorm
-        _ => "🌡️",             // Default/unknown
+        _ => "❓",             // Default/unknown
     };
 
     // Night icons for clear and partly cloudy conditions

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         wind_speed_10m,wind_direction_10m,wind_gusts_10m\
         &hourly=temperature_2m,precipitation_probability\
         &forecast_hours=8\
-        &temperature_unit={}&wind_speed_unit={}&precipitation_unit={}",
+        &temperature_unit={}&wind_speed_unit={}&precipitation_unit={}&timezone=auto",
         args.lat, args.lon, args.units_temperature, args.units_wind_speed, args.units_precipitation
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,11 +96,6 @@ fn main() {
         args.lat, args.lon, args.units_temperature, args.units_wind_speed, args.units_precipitation
     );
 
-    let aqi_param = match args.aqi_standard {
-        AqiStandard::European => "european_aqi",
-        AqiStandard::Us => "us_aqi",
-    };
-
     let domain_param = match args.aqi_domain {
         AqiDomain::Auto => "auto",
         AqiDomain::CamsEurope => "cams_europe",
@@ -109,11 +104,10 @@ fn main() {
 
     let air_quality_url = format!(
         "https://air-quality-api.open-meteo.com/v1/air-quality?latitude={}&longitude={}\
-        &hourly={}\
+        &hourly=european_aqi,us_aqi\
         &forecast_hours=8\
         &domains={}",
         args.lat, args.lon,
-        aqi_param,
         domain_param
     ); 
 
@@ -138,12 +132,12 @@ fn main() {
                 hourly_units: report::AirQualityHourlyUnits {
                     time: CompactString::from("iso8601"),
                     european_aqi: CompactString::from(""),
-                    us_aqi: None,
+                    us_aqi: CompactString::from(""),
                 },
                 hourly: report::AirQualityHourly {
                     time: Vec::new(),
                     european_aqi: Vec::new(),
-                    us_aqi: None,
+                    us_aqi: Vec::new(),
                 },
             }
         }
@@ -228,14 +222,10 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
                 }
             },
             AqiStandard::Us => {
-                if let Some(us_aqi) = &air_quality.hourly.us_aqi {
-                    if !us_aqi.is_empty() {
-                        let aqi = us_aqi[0];
-                        let emoji = get_us_aqi_emoji(aqi);
-                        format!("😷 Air Quality: {} {}", aqi, emoji)
-                    } else {
-                        String::from("😷 Air Quality: N/A ❓")
-                    }
+                if !air_quality.hourly.us_aqi.is_empty() {
+                    let aqi = air_quality.hourly.us_aqi[0];
+                    let emoji = get_us_aqi_emoji(aqi);
+                    format!("😷 Air Quality: {} {}", aqi, emoji)
                 } else {
                     String::from("😷 Air Quality: N/A ❓")
                 }
@@ -299,14 +289,10 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
                 }
             },
             AqiStandard::Us => {
-                if let Some(us_aqi) = &air_quality.hourly.us_aqi {
-                    if !us_aqi.is_empty() && i < us_aqi.len() {
-                        let aqi = us_aqi[i];
-                        let emoji = get_us_aqi_emoji(aqi);
-                        format!("{:>3} {}", aqi, emoji)
-                    } else {
-                        String::from("N/A ❓")
-                    }
+                if !air_quality.hourly.us_aqi.is_empty() && i < air_quality.hourly.us_aqi.len() {
+                    let aqi = air_quality.hourly.us_aqi[i];
+                    let emoji = get_us_aqi_emoji(aqi);
+                    format!("{:>3} {}", aqi, emoji)
                 } else {
                     String::from("N/A ❓")
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,36 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
         );
     }
 
+    // Get current AQI (first hour value)
+    if !air_quality.hourly.time.is_empty() {
+        let current_aqi_info = match aqi_standard {
+            AqiStandard::European => {
+                if !air_quality.hourly.european_aqi.is_empty() {
+                    let aqi = air_quality.hourly.european_aqi[0];
+                    let emoji = get_european_aqi_emoji(aqi);
+                    format!("😷 Air Quality: {} {}", aqi, emoji)
+                } else {
+                    String::from("😷 Air Quality: N/A ❓")
+                }
+            },
+            AqiStandard::Us => {
+                if let Some(us_aqi) = &air_quality.hourly.us_aqi {
+                    if !us_aqi.is_empty() {
+                        let aqi = us_aqi[0];
+                        let emoji = get_us_aqi_emoji(aqi);
+                        format!("😷 Air Quality: {} {}", aqi, emoji)
+                    } else {
+                        String::from("😷 Air Quality: N/A ❓")
+                    }
+                } else {
+                    String::from("😷 Air Quality: N/A ❓")
+                }
+            }
+        };
+
+        tooltip = format!("{}\n{}", tooltip, current_aqi_info);
+    }
+
     // Add hourly forecast information
     tooltip = format!("{}\n\n--------- Hourly Forecast ---------", tooltip);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,49 +110,66 @@ fn main() {
 fn format_output(report: &WeatherReportCurrent) -> Value {
     let temp = report.current.temperature_2m;
 
+    // Get weather icon based on weather code - now using colored emojis
     let mut icon = match &report.current.weather_code {
-        0 => "",
-        1 | 2 => "",
-        3 => "󰖐",
-        45 | 48 => "",
-        51 | 53 | 55 => "",
-        56 | 57 => "󰙿",
-        61 | 63 | 65 => "",
-        66 | 67 => "󰙿",
-        71 | 73 | 75 | 77 => "",
-        80..=82 => "",
-        85 | 86 => "",
-        95..=97 => "󰖓",
-
-        _ => "",
+        0 => "☀️",         // Clear sky
+        1 | 2 => "🌤️",    // Partly cloudy
+        3 => "☁️",         // Overcast
+        45 | 48 => "🌫️",   // Fog
+        51 | 53 | 55 => "🌦️", // Drizzle
+        56 | 57 => "🌨️",      // Freezing drizzle
+        61 | 63 | 65 => "🌧️", // Rain
+        66 | 67 => "🌨️",      // Freezing rain
+        71 | 73 | 75 | 77 => "❄️", // Snow
+        80..=82 => "🌧️",       // Rain showers
+        85 | 86 => "🌨️",       // Snow showers
+        95..=97 => "⛈️",       // Thunderstorm
+        _ => "🌡️",             // Default/unknown
     };
 
+    // Night icons for clear and partly cloudy conditions
     let icon_night = match &report.current.weather_code {
-        0 => "",
-        1 | 2 => "",
+        0 => "🌙",         // Clear night
+        1 | 2 => "☁️",     // Partly cloudy night
         _ => icon,
     };
 
+    // Use night icon if it's night
     if report.current.is_day == 0 {
-        icon = icon_night
+        icon = icon_night;
     }
 
+    // Current weather information
     let mut tooltip = format!(
-        "󰖝 {} {}\r {}{}\r󰖐 {}{}",
-        report.current.wind_speed_10m,
-        report.current_units.wind_speed_10m,
-        report.current.relative_humidity_2m,
-        report.current_units.relative_humidity_2m,
-        report.current.cloud_cover,
-        report.current_units.cloud_cover
+        "Current Conditions\n\n\
+        🌡️ Feels like: {}{}\n\
+        💨 Wind: {} {}\n\
+        💧 Humidity: {}{}\n\
+        ☁️ Cloud cover: {}{}",
+        report.current.apparent_temperature, temp_unit,
+        report.current.wind_speed_10m, report.current_units.wind_speed_10m,
+        report.current.relative_humidity_2m, report.current_units.relative_humidity_2m,
+        report.current.cloud_cover, report.current_units.cloud_cover
     );
 
+    // Add precipitation info if present
     if report.current.precipitation > 0.0 {
-        tooltip = format!("{}\n {}", tooltip, report.current.precipitation);
+        tooltip = format!(
+            "{}\n🌧️ Precipitation: {} {}",
+            tooltip, 
+            report.current.precipitation,
+            report.current_units.precipitation
+        );
     }
 
+    // Add snowfall info if present
     if report.current.snowfall > 0.0 {
-        tooltip = format!("{}\n {}", tooltip, report.current.snowfall);
+        tooltip = format!(
+            "{}\n❄️ Snowfall: {} {}", 
+            tooltip, 
+            report.current.snowfall,
+            report.current_units.snowfall
+        );
     }
 
     let waybar_output = WaybarOutput {

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,9 +266,9 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
                 if !air_quality.hourly.european_aqi.is_empty() && i < air_quality.hourly.european_aqi.len() {
                     let aqi = air_quality.hourly.european_aqi[i];
                     let emoji = get_european_aqi_emoji(aqi);
-                    format!("AQI: {} {}", aqi, emoji)
+                    format!("{:>3} {}", aqi, emoji)
                 } else {
-                    String::from("AQI: N/A")
+                    String::from("N/A ❓")
                 }
             },
             AqiStandard::Us => {
@@ -276,19 +276,18 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
                     if !us_aqi.is_empty() && i < us_aqi.len() {
                         let aqi = us_aqi[i];
                         let emoji = get_us_aqi_emoji(aqi);
-                        format!("AQI: {} {}", aqi, emoji)
+                        format!("{:>3} {}", aqi, emoji)
                     } else {
-                        String::from("AQI: N/A")
+                        String::from("N/A ❓")
                     }
                 } else {
-                    String::from("AQI: N/A")
+                    String::from("N/A ❓")
                 }
             }
         };
 
-        // Add hourly data line with fixed width formatting including AQI
         tooltip = format!(
-            "{}\n{:<5} | {:>3}{}° | 🌧️{:>3}% | {}",
+            "{}\n{:<5} | {:>3}{}° | 🌧️{:>3}% | AQI: {:>5}",
             tooltip,
             hour_str,
             hour_temp.round() as i32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
-use crate::report::WeatherReportCurrent;
+use crate::report::{WeatherReport, AirQualityReport};
 use clap::Parser;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use compact_str::CompactString;
 
 mod report;
 
@@ -82,7 +83,6 @@ struct WaybarOutput {
 
 fn main() {
     let client = Client::new();
-
     let args = Args::parse();
 
     // Weather API URL

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,6 @@ fn main() {
     let client = Client::new();
     let args = Args::parse();
 
-    // Weather API URL
     let weather_url = format!(
         "https://api.open-meteo.com/v1/forecast?latitude={}&longitude={}\
         &current=temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,\
@@ -198,7 +197,6 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
         report.current.cloud_cover, report.current_units.cloud_cover
     );
 
-    // Add precipitation info if present
     if report.current.precipitation > 0.0 {
         tooltip = format!(
             "{}\n🌧️ Precipitation: {} {}",
@@ -208,7 +206,6 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
         );
     }
 
-    // Add snowfall info if present
     if report.current.snowfall > 0.0 {
         tooltip = format!(
             "{}\n❄️ Snowfall: {} {}", 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,12 +85,15 @@ fn main() {
 
     let args = Args::parse();
 
-    let url = format!(
+    // Weather API URL
+    let weather_url = format!(
         "https://api.open-meteo.com/v1/forecast?latitude={}&longitude={}\
         &current=temperature_2m,relative_humidity_2m,apparent_temperature,is_day,precipitation,\
         rain,showers,snowfall,weather_code,cloud_cover,pressure_msl,surface_pressure,\
-        wind_speed_10m,wind_direction_10m,wind_gusts_10m&\
-        temperature_unit={}&wind_speed_unit={}&precipitation_unit={}",
+        wind_speed_10m,wind_direction_10m,wind_gusts_10m\
+        &hourly=temperature_2m,precipitation_probability\
+        &forecast_hours=8\
+        &temperature_unit={}&wind_speed_unit={}&precipitation_unit={}",
         args.lat, args.lon, args.units_temperature, args.units_wind_speed, args.units_precipitation
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,8 +188,7 @@ fn format_output(report: &WeatherReport, air_quality: &AirQualityReport, aqi_sta
 
     // Current weather information
     let mut tooltip = format!(
-        "Current Conditions\n\n\
-        🌡️ Feels like: {}{}\n\
+        "🌡️ Feels like: {}{}\n\
         💨 Wind: {} {}\n\
         💧 Humidity: {}{}\n\
         ☁️ Cloud cover: {}{}",

--- a/src/report.rs
+++ b/src/report.rs
@@ -46,4 +46,28 @@ pub struct Current {
 pub struct WeatherReportCurrent {
     pub current_units: CurrentUnits,
     pub current: Current,
+    pub hourly_units: HourlyUnits,
+    pub hourly: Hourly,
+}
+
+// Add new structs for air quality data
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AirQualityHourlyUnits {
+    pub time: CompactString,
+    pub european_aqi: CompactString,
+    pub us_aqi: Option<CompactString>,
+}
+
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AirQualityHourly {
+    pub time: Vec<CompactString>,
+    pub european_aqi: Vec<u8>,
+    pub us_aqi: Option<Vec<u16>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AirQualityReport {
+    pub hourly_units: AirQualityHourlyUnits,
+    pub hourly: AirQualityHourly,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -16,7 +16,7 @@ pub struct CurrentUnits {
     pub cloud_cover: CompactString,
     pub pressure_msl: CompactString,
     pub surface_pressure: CompactString,
-    pub wind_speed_10m:	CompactString,
+    pub wind_speed_10m: CompactString,
     pub wind_direction_10m: CompactString,
     pub wind_gusts_10m: CompactString,
 }
@@ -37,13 +37,27 @@ pub struct Current {
     pub cloud_cover: f32,
     pub pressure_msl: f32,
     pub surface_pressure: f32,
-    pub wind_speed_10m:	f32,
+    pub wind_speed_10m: f32,
     pub wind_direction_10m: f32,
     pub wind_gusts_10m: f32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct WeatherReportCurrent {
+pub struct HourlyUnits {
+    pub time: CompactString,
+    pub temperature_2m: CompactString,
+    pub precipitation_probability: CompactString,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Hourly {
+    pub time: Vec<CompactString>,
+    pub temperature_2m: Vec<f32>,
+    pub precipitation_probability: Vec<f32>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct WeatherReport {
     pub current_units: CurrentUnits,
     pub current: Current,
     pub hourly_units: HourlyUnits,

--- a/src/report.rs
+++ b/src/report.rs
@@ -68,6 +68,7 @@ pub struct WeatherReport {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AirQualityHourlyUnits {
     pub time: CompactString,
+    #[serde(default)]
     pub european_aqi: CompactString,
     pub us_aqi: Option<CompactString>,
 }
@@ -76,6 +77,7 @@ pub struct AirQualityHourlyUnits {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AirQualityHourly {
     pub time: Vec<CompactString>,
+    #[serde(default)]
     pub european_aqi: Vec<u8>,
     pub us_aqi: Option<Vec<u16>>,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -70,7 +70,8 @@ pub struct AirQualityHourlyUnits {
     pub time: CompactString,
     #[serde(default)]
     pub european_aqi: CompactString,
-    pub us_aqi: Option<CompactString>,
+    #[serde(default)]
+    pub us_aqi: CompactString,
 }
 
 
@@ -79,7 +80,8 @@ pub struct AirQualityHourly {
     pub time: Vec<CompactString>,
     #[serde(default)]
     pub european_aqi: Vec<u8>,
-    pub us_aqi: Option<Vec<u16>>,
+    #[serde(default)]
+    pub us_aqi: Vec<u16>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
I hacked this one together yesterday. A lot of changes and a bit messy, but hopefully understandable.

There are several changes to the way things look and work:

- Switched from nerd font icons to emojis (easier to understand AQI data that way);
- Reworked the current conditions to show emojis and added descriptions to fill up the content in the top half of the tooltip;
- Introduced the hourly forecast table that shows hourly information for the next 8 hours. It shows the hour, the projected temperature, precipitation chances, and the projected air quality;
- Added the proper Open Meteo API for retrieving air quality data;
- Added the proper parameters for selecting the data sources: --aqi-standard (european or us) --aqi-domain (auto, cams-global, cams-europe)
- Added emojis that signal air quality based on the scale/standard used. 

Again, I hacked this one together and I’m no programmer, so there could be bugs or things wrong.

Here’s a preview:

![tooltip](https://github.com/user-attachments/assets/c54abb91-002b-4f19-aa6a-2f6c559db439)
