### PR TITLE
gracefully handle network errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::time::Duration;
 
 mod report;
 
@@ -90,8 +91,63 @@ struct WaybarOutput {
     tooltip: String,
 }
 
+fn fetch_weather(client: &Client, url: &str) -> Result<WeatherReport, String> {
+    let backoffs = [0, 2, 4];
+
+    for i in 0..backoffs.len() {
+        if backoffs[i] > 0 {
+            std::thread::sleep(Duration::from_secs(backoffs[i] as u64));
+        }
+
+        match client.get(url).send() {
+            Ok(response) => {
+                if !response.status().is_success() {
+                    continue;
+                }
+                if let Ok(report) = response.json::<WeatherReport>() {
+                    return Ok(report);
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    Err("All attempts failed".to_string())
+}
+
+fn fetch_air_quality(client: &Client, url: &str) -> Option<AirQualityReport> {
+    let backoffs = [0, 2, 4];
+
+    for i in 0..backoffs.len() {
+        if backoffs[i] > 0 {
+            std::thread::sleep(Duration::from_secs(backoffs[i] as u64));
+        }
+
+        if let Ok(response) = client.get(url).send() {
+            if response.status().is_success() {
+                if let Ok(report) = response.json::<AirQualityReport>() {
+                    return Some(report);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn format_fallback() -> Value {
+    json!({
+        "text": "⚠ --",
+        "tooltip": "Unable to fetch weather data"
+    })
+}
+
 fn main() {
-    let client = Client::new();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("Failed to create HTTP client");
+
     let args = Args::parse();
 
     let weather_url = format!(
@@ -119,23 +175,15 @@ fn main() {
         args.lat, args.lon, domain_param
     );
 
-    let weather_report = match client.get(&weather_url).send() {
-        Ok(response) => response
-            .json::<WeatherReport>()
-            .expect("Invalid response from weather API"),
+    let weather_report = match fetch_weather(&client, &weather_url) {
+        Ok(report) => report,
         Err(_) => {
-            eprintln!("Connection error to weather API");
-            std::process::exit(1);
+            println!("{}", format_fallback());
+            return;
         }
     };
 
-    let air_quality_report = match client.get(&air_quality_url).send() {
-        Ok(response) => response.json::<AirQualityReport>().ok(),
-        Err(e) => {
-            eprintln!("Connection error to air quality API: {}", e);
-            None
-        }
-    };
+    let air_quality_report = fetch_air_quality(&client, &air_quality_url);
 
     println!(
         "{}",


### PR DESCRIPTION
Hi @marcinmdev! 

I’ve been having some network/DNS errors with my new provider that cause stormwind to not retrieve the temperature data properly. As a consequence, randomly during the day stormwind would fail to sync new data, sometimes multiple times a day. 

When it would fail, the entire weather module would just disappear completely from waybar until the next sync time (in my case 30 minutes later), or until I restarted waybar which would force another sync. This forced sync would always work, and this is how I understood that this was an issue with my network and some intermittent issues. I also realised that perhaps stormwind could handle these unexpected situations a bit better.

The pull request encompasses two small changes:

1. When the program fails to retrieve data for any reason (like no network connection), now there is a tooltip and a graphical error indicator "⚠ --" that will be shown in place of the temperature, instead of nothing.
2. There is now a mechanism during data retrieval that’s meant to catch intermittent network issues by checking what’s been retrieved. If there are issues it will try a few times to re-fetch data in order to avoid the failure state. I’ve been testing the changes on my main machine for several days and it seems to have resolved my specific network quality issues. I now get consistent performance i.e. the data has not failed to fetch once.

As is, the system only tries to refetch a couple of times with a backoff timer so as not to hammer the API needlessly. Given the timings, I don’t think this will work well for very short refresh times, but I don’t believe anyone uses stormwind with refresh times of under 60s?